### PR TITLE
Replace obsolete functions and set destructors virtual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.20)
+project(QHexEdit CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Widgets Gui REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets Gui REQUIRED)
+
+set(PROJECT_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/hexcommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/insertcommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/removecommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/replacecommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/gapbuffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhexcursor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhexdocument.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhextheme.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paint/qhexmetrics.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paint/qhexpainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/qhexedit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/qhexeditprivate.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/metadata/qhexmetadataitem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/metadata/qhexmetadata.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/hexcommand.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/insertcommand.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/removecommand.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/commands/replacecommand.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/gapbuffer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhexcursor.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhexdocument.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/qhextheme.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/paint/qhexmetrics.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/paint/qhexpainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/qhexedit.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/qhexeditprivate.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/metadata/qhexmetadataitem.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/document/metadata/qhexmetadata.h
+    )
+if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    qt_add_library(QHexEdit
+        STATIC
+        MANUAL_FINALIZATION
+        ${PROJECT_SOURCES}
+    )
+else()
+    add_library(QHexEdit${PROJECT_SOURCES})
+endif()
+target_include_directories(QHexEdit SYSTEM
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/paint
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/document
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/document/commands
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/document/metadata
+)
+
+target_link_libraries(QHexEdit PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets  Qt${QT_VERSION_MAJOR}::Gui)
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_finalize_target(QHexEdit)
+endif()

--- a/document/qhexcursor.h
+++ b/document/qhexcursor.h
@@ -14,7 +14,7 @@ class QHexCursor : public QObject
 
     public:
         explicit QHexCursor(QObject *parent = 0);
-        ~QHexCursor();
+        virtual ~QHexCursor() override;
         QPoint position() const;
         sinteger_t cursorX() const;
         sinteger_t cursorY() const;

--- a/document/qhexdocument.h
+++ b/document/qhexdocument.h
@@ -16,7 +16,7 @@ class QHexDocument: public QObject
 
     private:
         explicit QHexDocument(QIODevice* device, QObject *parent = 0);
-        ~QHexDocument();
+        virtual ~QHexDocument()override;
 
     public:
         QHexCursor* cursor() const;

--- a/paint/qhexmetrics.cpp
+++ b/paint/qhexmetrics.cpp
@@ -93,7 +93,7 @@ void QHexMetrics::calculate(const QFontMetrics &fm)
 {
     this->calculateAddressWidth();
 
-    this->_charwidth = fm.width(" ");
+    this->_charwidth = fm.horizontalAdvance(" ");
     this->_charheight = fm.height();
 
     this->_xposhex = this->_charwidth * (this->_addresswidth + 1);

--- a/paint/qhexpainter.cpp
+++ b/paint/qhexpainter.cpp
@@ -135,14 +135,14 @@ void QHexPainter::drawAddress(QPainter *painter, QHexTheme* theme, integer_t lin
         painter->setPen(theme->addressForeground());
 
     QString addr = QString("%1").arg(this->_document->baseAddress() + (line * QHexMetrics::BYTES_PER_LINE), this->_metrics->addressWidth(), 16, QLatin1Char('0')).toUpper();
-    painter->drawText(0, y, fm.width(addr), this->_metrics->charHeight(), Qt::AlignLeft | Qt::AlignTop, addr);
+    painter->drawText(0, y, fm.horizontalAdvance(addr), this->_metrics->charHeight(), Qt::AlignLeft | Qt::AlignTop, addr);
 }
 
 void QHexPainter::drawHex(QPainter *painter, uchar b, sinteger_t i, integer_t offset, integer_t &x, integer_t y)
 {
     QString s = QString("%1").arg(b, 2, 16, QLatin1Char('0')).toUpper();
     QFontMetrics fm = containerWidget->fontMetrics();
-    QRect r(x, y, fm.width(s), this->_metrics->charHeight());
+    QRect r(x, y, fm.horizontalAdvance(s), this->_metrics->charHeight());
 
     this->mark(painter, r, offset, QHexCursor::HexPart);
 
@@ -164,12 +164,12 @@ void QHexPainter::drawAscii(QPainter *painter, uchar b, integer_t offset, intege
 
     if(QChar(b).isPrint())
     {
-        w = fm.width(b);
-        s = QString(b);
+        w = fm.horizontalAdvance(QChar(b));
+        s = QString(QChar(b));
     }
     else
     {
-        w = fm.width(QHexPainter::UNPRINTABLE_CHAR);
+        w = fm.horizontalAdvance(QHexPainter::UNPRINTABLE_CHAR);
         s = QHexPainter::UNPRINTABLE_CHAR;
     }
 

--- a/qhexedit.cpp
+++ b/qhexedit.cpp
@@ -21,7 +21,7 @@ QHexEdit::QHexEdit(QWidget *parent): QFrame(parent)
 
     this->_hlayout = new QHBoxLayout();
     this->_hlayout->setSpacing(0);
-    this->_hlayout->setMargin(0);
+    this->_hlayout->setContentsMargins(0,0,0,0);
     this->_hlayout->addWidget(this->_scrollarea);
     this->_hlayout->addWidget(this->_vscrollbar);
 

--- a/qhexeditprivate.cpp
+++ b/qhexeditprivate.cpp
@@ -135,7 +135,7 @@ void QHexEditPrivate::processBackspaceEvents()
 void QHexEditPrivate::processHexPart(int key)
 {
     QHexCursor* cursor = this->_document->cursor();
-    uchar val = static_cast<uchar>(QString(key).toUInt(NULL, 16));
+    uchar val = static_cast<uchar>(QString(QChar(key)).toUInt(NULL, 16));
 
     cursor->removeSelection();
 
@@ -410,14 +410,14 @@ void QHexEditPrivate::mouseMoveEvent(QMouseEvent* event)
 
 void QHexEditPrivate::wheelEvent(QWheelEvent *event)
 {
-    if(!this->_document || !this->_document->length() || (event->orientation() != Qt::Vertical))
+    if(!this->_document || !this->_document->length() || (event->angleDelta().x() != 0))
     {
         event->ignore();
         return;
     }
 
     QHexCursor* cursor = this->_document->cursor();
-    sinteger_t numdegrees = event->delta() / 8, numsteps = numdegrees / 15;
+    sinteger_t numdegrees = event->pixelDelta().y() / 8, numsteps = numdegrees / 15;
     sinteger_t maxlines = this->_document->length() / QHexMetrics::BYTES_PER_LINE;
     sinteger_t pos = this->_vscrollbar->sliderPosition() - (numsteps * QHexEditPrivate::WHELL_SCROLL_LINES);
 


### PR DESCRIPTION
QObject derived classes should have virtual destructors, so that these destructors will get called when qt automatically delete the base class pointer.
